### PR TITLE
Add new bank IDs and branches ranges.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2019-08-09
+### Modified
+- Update bankData to match 2020 Resident Withholding Tax (RWT) and Non-Resident Withholding Tax (NRWT).
+- Cross reference with https://www.paymentsnz.co.nz/resources/industry-registers/bank-branch-register/
+
 
 ## [1.0.2] - 2019-01-30
 ### Modified

--- a/README.md
+++ b/README.md
@@ -50,9 +50,11 @@ The first step in the validation process is to verify the bank branch number. Fo
 |01|0001 - 0999, 1100 - 1199, 1800 - 1899|See note|
 |02|0001 - 0999, 1200 - 1299|See note|
 |03|0001 - 0999, 1300 - 1399, 1500 - 1599, 1700 – 1799 , 1900 - 1999|See note|
+|04|2020 - 2024||
 |06|0001 - 0999, 1400 - 1499|See note|
 |08|6500 - 6599|D|
 |09|0000|E|
+|10|5165 - 5169|See note|
 |11|5000 - 6499, 6600 - 8999|See note|
 |12|3000 - 3299, 3400 – 3499, 3600 - 3699|See note|
 |13|4900 - 4999|See note|
@@ -77,6 +79,7 @@ The first step in the validation process is to verify the bank branch number. Fo
 |33|6700 - 6799|F|
 |35|2400 - 2499|See note|
 |38|9000 - 9499|See note|
+|88|8800 - 8805||
 
 **Note**: If the account base number is below 00990000 then apply algorithm A, otherwise apply algorithm B.
 

--- a/bankData.js
+++ b/bankData.js
@@ -340,6 +340,6 @@ const bankData = [
       }
     ]
   }
-];
+]
 
-exports.bankData = bankData;
+exports.bankData = bankData

--- a/bankData.js
+++ b/bankData.js
@@ -55,6 +55,15 @@ const bankData = [
     ]
   },
   {
+    id: 4,
+    branches: [
+      {
+        from: 2020,
+        to: 2024
+      }
+    ]
+  },
+  {
     id: 6,
     branches: [
       {
@@ -83,6 +92,15 @@ const bankData = [
         from: 0,
         to: 0
       }
+    ]
+  },
+  {
+    id: 10,
+    branches: [
+      {
+        from: 5165,
+        to: 5169
+      },
     ]
   },
   {
@@ -312,7 +330,16 @@ const bankData = [
         to: 9499
       }
     ]
+  },
+  {
+    id: 88,
+    branches: [
+      {
+        from: 8800,
+        to: 8805
+      }
+    ]
   }
-]
+];
 
-exports.bankData = bankData
+exports.bankData = bankData;

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ const getModulo = (bankId) => {
 const isValidNZBankNumber = (bk, brch, acct, suf) => {
   const bank = leftPad(bk, 2, '0')
   const branch = leftPad(brch, 4, '0')
-  const account = leftPad(acct,8, '0')
+  const account = leftPad(acct, 8, '0')
   const suffix = leftPad(suf, 4, '0')
   if (+account === 0) return false
   if (!isValidBankAndBranch(bank, branch)) return false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fnzc/nz-bank-account-validator",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Validates New Zealand bank accounts",
   "main": "index.js",
   "typings": "./index.d.ts",


### PR DESCRIPTION
Added banks 4, 10 and 88.

Banks 4 and 10 are referenced in both sources.
Bank 88 is only listed in paymentsnz.

paymentsnz doesn't list bank IDs 33, 35. I have left them in for now so as to not break anything.

References:

- https://www.paymentsnz.co.nz/resources/industry-registers/bank-branch-register/, 

- https://www.ird.govt.nz/-/media/Project/IR/PDF/2020RWTNRWTSpecificationDocumentv10.pdf

I can't work out what algorithm checks are required.